### PR TITLE
Add some useful flags to satisfy some new usecases

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,7 @@ linters-settings:
       - whyNoLint
       - wrapperFunc
   gocyclo:
-    min-complexity: 17
+    min-complexity: 18
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   golint:


### PR DESCRIPTION
```
  -f, --force                Ignore a dirty repository.
  -p, --prefix               Add the 'v' prefix to the output version.
      --release              Fail if this is a dev, pre-release or dirty version.
```