### PR TITLE
Enable sver to work with safe directory

### DIFF
--- a/gh-action-entrypoint.sh
+++ b/gh-action-entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 export PRE_RELEASE="$INPUT_PRE_RELEASE"
 
+if [ -n ${GITHUB_WORKSPACE} ]; then
+  git config --global --add safe.directory "$GITHUB_WORKSPACE"
+fi
+
 if [ -n "${INPUT_DOCKER_IMAGE}" ]; then
   version=$(/app/sver tags -s "${INPUT_DOCKER_REGISTRY}" -u "${INPUT_DOCKER_USERNAME}" -p "${INPUT_DOCKER_PASSWORD}" "${INPUT_DOCKER_IMAGE}")
 elif [ -n "${INPUT_NEXT}" ]; then

--- a/pkg/sver/git.go
+++ b/pkg/sver/git.go
@@ -1,6 +1,7 @@
 package sver
 
 import (
+	"bytes"
 	"os/exec"
 	"strings"
 
@@ -24,9 +25,11 @@ func verifyGit() error {
 	}
 
 	cmd := exec.Command(gitBinary, "rev-parse", "--is-inside-work-tree")
+	stdErrBuf := new(bytes.Buffer)
+	cmd.Stderr = stdErrBuf
 	err = cmd.Run()
 	if err != nil {
-		return errors.New("current directory is not a git working tree")
+		return errors.Wrapf(err, "could not determine if the current directory is a git working tree: %s", stdErrBuf.String())
 	}
 
 	return nil


### PR DESCRIPTION
Git version 2.36.x added the notion of [safe.directory](https://git-scm.com/docs/git-config/2.36.0#Documentation/git-config.txt-safedirectory) this causes `sver` to fail if it is executed using the [sver-action](https://github.com/aserto-dev/sver-action) on a docker container that has `git` > 2.36.x.

This PR adds the `$GITHUB_WORKSPACE` as a global safe directory and also makes sver show a meaningful error in case the git repo check fails.